### PR TITLE
Remove six dependency.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
 flake8
-six
-

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ more to learn about it.
       url='http://pythonpaste.org/tempita/',
       license='MIT',
       packages=['tempita'],
-      install_requires=['six'],
       tests_require=['nose'],
       test_suite='nose.collector',
       include_package_data=True,

--- a/tempita/__init__.py
+++ b/tempita/__init__.py
@@ -28,6 +28,7 @@ can use ``__name='tmpl.html'`` to set the name of the template.
 
 If there are syntax errors ``TemplateError`` will be raised.
 """
+from __future__ import absolute_import, division, print_function
 
 import re
 import sys
@@ -43,8 +44,8 @@ import os
 import tokenize
 from ._looper import looper
 from .compat3 import (
-    PY3, bytes, basestring_, next, is_unicode, coerce_text)
-import six
+    PY3, bytes, basestring_, next, is_unicode, coerce_text, iteritems)
+
 
 __all__ = ['TemplateError', 'Template', 'sub', 'HTMLTemplate',
            'sub_html', 'html', 'bunch']
@@ -209,7 +210,7 @@ class Template(object):
                 position=None, name=self.name)
         templ = self.get_template(inherit_template, self)
         self_ = TemplateObject(self.name)
-        for name, value in six.iteritems(defs):
+        for name, value in iteritems(defs):
             setattr(self_, name, value)
         self_.body = body
         ns = ns.copy()
@@ -405,7 +406,7 @@ def paste_script_template_renderer(content, vars, filename=None):
 class bunch(dict):
 
     def __init__(self, **kw):
-        for name, value in six.iteritems(kw):
+        for name, value in iteritems(kw):
             setattr(self, name, value)
 
     def __setattr__(self, name, value):
@@ -428,7 +429,7 @@ class bunch(dict):
 
     def __repr__(self):
         items = [
-            (k, v) for k, v in six.iteritems(self)]
+            (k, v) for k, v in iteritems(self)]
         items.sort()
         return '<%s %s>' % (
             self.__class__.__name__,
@@ -481,7 +482,7 @@ def url(v):
 
 
 def attr(**kw):
-    kw = list(six.iteritems(kw))
+    kw = list(iteritems(kw))
     kw.sort()
     parts = []
     for name, value in kw:
@@ -562,7 +563,7 @@ class TemplateDef(object):
         values = {}
         sig_args, var_args, var_kw, defaults = self._func_signature
         extra_kw = {}
-        for name, value in six.iteritems(kw):
+        for name, value in iteritems(kw):
             if not var_kw and name not in sig_args:
                 raise TypeError(
                     'Unexpected argument %s' % name)
@@ -585,7 +586,7 @@ class TemplateDef(object):
                 raise TypeError(
                     'Extra position arguments: %s'
                     % ', '.join(repr(v) for v in args))
-        for name, value_expr in six.iteritems(defaults):
+        for name, value_expr in iteritems(defaults):
             if name not in values:
                 values[name] = self._template._eval(
                     value_expr, self._ns, self._pos)

--- a/tempita/_looper.py
+++ b/tempita/_looper.py
@@ -17,9 +17,10 @@ looper you can get a better sense of the context.  Use like::
     3 c
 
 """
+from __future__ import absolute_import, division, print_function
 
 import sys
-from tempita.compat3 import basestring_
+from .compat3 import basestring_
 
 __all__ = ['looper']
 

--- a/tempita/compat3.py
+++ b/tempita/compat3.py
@@ -1,28 +1,38 @@
+from __future__ import absolute_import, division, print_function
+
 import sys
 
-__all__ = ['PY3', 'b', 'basestring_', 'bytes', 'next', 'is_unicode']
+__all__ = ['PY3', 'b', 'basestring_', 'bytes', 'next', 'is_unicode',
+           'iteritems']
 
 PY3 = True if sys.version_info[0] == 3 else False
 
 if sys.version_info[0] < 3:
+
+    def next(obj):
+        return obj.next()
+
+    def iteritems(d, **kw):
+        return d.iteritems(**kw)
+
     b = bytes = str
     basestring_ = basestring
+
 else:
 
     def b(s):
         if isinstance(s, str):
             return s.encode('latin1')
         return bytes(s)
+
+    def iteritems(d, **kw):
+        return iter(d.items(**kw))
+
+    next = next
     basestring_ = (bytes, str)
     bytes = bytes
+
 text = str
-
-if sys.version_info[0] < 3:
-
-    def next(obj):
-        return obj.next()
-else:
-    next = next
 
 
 def is_unicode(obj):


### PR DESCRIPTION
- Remove six.iteritems and implement iteritems in compat3.py.
- Add python2/Python3 `from __future__` compatibility boilerplate.

Note that `next` and `bytes` were both added in Python 2.6. Since tempita already uses `bytes`, might as well remove the `next` implementation. The `iteritems` function isn't really needed either, as `d.items()` will work fine for the current code, it is just a bit slower for Python 2 `for` loops as it returns a list instead of an iterator. 